### PR TITLE
Introduces uncyber mappings for APT, bitcoin; aggregates double mappings

### DIFF
--- a/content.js
+++ b/content.js
@@ -15,10 +15,9 @@ const sourceWordsToTargetWords = [
     [['disruptive'], 'boring'],
     [['blockchain'], 'mythical tech'],
     [['cyber'], 'IT'],
-    [['gartner'], 'generic analyst firm'],
-    [['idc'], 'generic analyst firm'],
-    [['forrester'], 'generic analyst firm'],
-    [['451 research'], 'generic analyst firm'],
+    [['gartner', 'idc', 'forrester', '451 research'], 'generic analyst firm'],
+    [['bitcoin', 'ethereum', 'litecoin'], 'magic internet money'],
+    [['APT', 'Advanced Persistent Threat'], 'unicorn attack'],
 ];
 
 /**


### PR DESCRIPTION
The existing uncyber mapping dictionary is already powerful enough
to map several cyber definitions towards their uncybered counterparts.
Several dictionary entries which map to the same uncybered words/phrases
are unified.

Furthermore the dictionary covers now the following cyberisms:
APT, bitcoin, litecoin, ethereum